### PR TITLE
update 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,18 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y openjdk-17-jdk android-sdk
-          mkdir -p ~/.android && touch ~/.android/repositories.cfg
-          export ANDROID_SDK_ROOT=$HOME/android-sdk
-          export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH
-          export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH
+          echo "export ANDROID_SDK_ROOT=$HOME/android-sdk" >> $HOME/.bashrc
+          echo "export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH" >> $HOME/.bashrc
+          echo "export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH" >> $HOME/.bashrc
+          echo "export PATH=$ANDROID_SDK_ROOT/tools/bin:$PATH" >> $HOME/.bashrc
+          source $HOME/.bashrc
+          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools/latest
+          cd $ANDROID_SDK_ROOT/cmdline-tools/latest
+          curl -o sdk-tools-linux.zip https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip
+          unzip sdk-tools-linux.zip
           yes | sdkmanager --licenses
           sdkmanager "platform-tools" "platforms;android-33" "build-tools;33.0.1"
+
 
       - name: Build APK Locally
         run: eas build --platform android --local --output ./build-output/apk-release.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,45 +8,41 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest  # Use GitHub's cloud infrastructure
-
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Setup repo
         uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      
+      - name: Setup node
+        uses: actions/setup-node@v4.0.2
         with:
-          node-version: 18  # Latest LTS version
+          node-version: 18.x
+          cache: 'npm'
 
-      - name: Install Dependencies
-        run: npm install
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-      - name: Install Expo CLI & EAS CLI
-        run: npm install -g expo-cli eas-cli
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
 
-      - name: Setup Android SDK & Gradle
-        run: |
-          sudo apt update
-          sudo apt install -y openjdk-17-jdk android-sdk
-          echo "export ANDROID_SDK_ROOT=$HOME/android-sdk" >> $HOME/.bashrc
-          echo "export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH" >> $HOME/.bashrc
-          echo "export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH" >> $HOME/.bashrc
-          echo "export PATH=$ANDROID_SDK_ROOT/tools/bin:$PATH" >> $HOME/.bashrc
-          source $HOME/.bashrc
-          mkdir -p $ANDROID_SDK_ROOT/cmdline-tools/latest
-          cd $ANDROID_SDK_ROOT/cmdline-tools/latest
-          curl -o sdk-tools-linux.zip https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip
-          unzip sdk-tools-linux.zip
-          yes | sdkmanager --licenses
-          sdkmanager "platform-tools" "platforms;android-33" "build-tools;33.0.1"
+      - name: Setup Expo
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
 
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Build APK Locally
-        run: eas build --platform android --local --output ./build-output/apk-release.apk
+      - name: Build Android app
+        run: eas build --platform android --profile preview --local --output ${{ github.workspace }}/app-release.apk
 
-      - name: Upload APK Artifact
+      - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: expo-apk
-          path: ./build-output/apk-release.apk
+          name: app-release
+          path: ${{ github.workspace }}/app-release.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Expo CI/CD Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  # Use GitHub's cloud infrastructure
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18  # Latest LTS version
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Install Expo CLI & EAS CLI
+        run: npm install -g expo-cli eas-cli
+
+      - name: Setup Android SDK & Gradle
+        run: |
+          sudo apt update
+          sudo apt install -y openjdk-17-jdk android-sdk
+          mkdir -p ~/.android && touch ~/.android/repositories.cfg
+          export ANDROID_SDK_ROOT=$HOME/android-sdk
+          export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH
+          export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH
+          yes | sdkmanager --licenses
+          sdkmanager "platform-tools" "platforms;android-33" "build-tools;33.0.1"
+
+      - name: Build APK Locally
+        run: eas build --platform android --local --output ./build-output/apk-release.apk
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: expo-apk
+          path: ./build-output/apk-release.apk


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build process for an Expo project. The workflow is designed to run on pushes to the `main` branch and on pull requests.

Key changes:

* **Workflow Configuration**:
  * Added a new workflow named `Expo CI/CD Build` in the `.github/workflows/build.yml` file.
  * Configured the workflow to trigger on pushes to the `main` branch and on pull requests.

* **Job Setup**:
  * Defined a job named `build` that runs on `ubuntu-latest`.
  * Included steps to set up the repository, Node.js, JDK 17, Android SDK, and Expo.
  * Added steps to install dependencies, build the Android app, and upload the APK artifact.